### PR TITLE
Separate Thread from Comments

### DIFF
--- a/controllers/thread.go
+++ b/controllers/thread.go
@@ -157,7 +157,7 @@ func DeleteThread(context *gin.Context) {
 func getThreadByID(id int) (*models.Thread, error) {
 	var thread models.Thread
 
-	result := initializers.DB.Preload("Author").Preload("Comments").Preload("Comments.Author").First(&thread, id)
+	result := initializers.DB.Preload("Author").First(&thread, id)
 
 	if result.Error != nil {
 		return nil, result.Error

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func setUpRouters(router *gin.Engine) {
 	// Comment endpoints
 	threadGroup := router.Group("/threads/:threadID")
 	threadGroup.POST("/comments", middleware.JWTAuthMiddleware, controllers.CreateComment)
+	threadGroup.GET("/comments/", controllers.GetComments)
 	threadGroup.GET("/comments/:commentID", controllers.GetComment)
 	threadGroup.PUT("/comments/:commentID", middleware.JWTAuthMiddleware, controllers.UpdateComment)
 	threadGroup.DELETE("/comments/:commentID", middleware.JWTAuthMiddleware, controllers.DeleteComment)

--- a/models/commentModel.go
+++ b/models/commentModel.go
@@ -8,6 +8,6 @@ type Comment struct {
 	UserID    uint   `gorm:"not null" json:"author_id,omitempty"`
 	Author    User   `gorm:"foreignKey:UserID" json:"author,omitempty"`
 	ThreadID  uint   `gorm:"not null" json:"thread_id,omitempty"`
-	Thread    Thread `gorm:"foreignKey:ThreadID" json:"thread,omitempty"`
+	Thread    Thread `gorm:"foreignKey:ThreadID" json:"-"`
 	CommentID uint   `gorm:"not null" json:"comment_id,omitempty"`
 }


### PR DESCRIPTION
- GET request to Thread does not return Comments under it
- create GET request to "/thread/:threadID/comments"
- remove Thread field from Comments to reduce clutter

This fixes #31 