### PR TITLE
Return user upon login

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -125,7 +125,7 @@ func Login(context *gin.Context) {
 
 	context.SetSameSite(http.SameSiteLaxMode)
 	context.SetCookie("Authorization", tokenString, configs.JWTExpirationTimeInSeconds, "", "", false, true)
-	context.IndentedJSON(http.StatusOK, gin.H{"message": "Login success"})
+	context.IndentedJSON(http.StatusOK, gin.H{"user": user})
 }
 
 func GetPrivateKey() *ecdsa.PrivateKey {


### PR DESCRIPTION
This allows the user to be stored on the frontend.
This opens up functionalities such as:

1. Update buttons shown only to the user who created a post/comment